### PR TITLE
Use the Kociemba solver by default, as the cfop library is missing

### DIFF
--- a/lib/rubyiks_cube/server.rb
+++ b/lib/rubyiks_cube/server.rb
@@ -3,14 +3,14 @@ require 'bundler'
 Bundler.setup
 require 'em-websocket'
 require 'kociemba'
-require 'cfop'
+# require 'cfop'
 require 'rubiks_cube'
 require 'benchmark'
 
 Kociemba::Cache.load_all
 
 k_solver = Kociemba::Solver.new
-cfop_solver = Cfop::Solver.new
+# cfop_solver = Cfop::Solver.new
 
 EM.run {
   EM::WebSocket.run(:host => "0.0.0.0", :port => 9292) do |ws|
@@ -25,10 +25,10 @@ EM.run {
     ws.onmessage { |msg|
       puts "Recieved cube: #{msg}"
       solution = nil
-      # results = Benchmark.measure { solution = k_solver.solve(msg, max_depth: 21) }
+      results = Benchmark.measure { solution = k_solver.solve(msg, max_depth: 21) }
       # results = Benchmark.measure { solution = cfop_solver.solve(msg, parts: :top) }
       # results = Benchmark.measure { solution = cfop_solver.solve(msg, parts: :f2l) }
-      results = Benchmark.measure { solution = cfop_solver.solve(msg, parts: :all) }
+      # results = Benchmark.measure { solution = cfop_solver.solve(msg, parts: :all) }
       puts "Solution: #{solution}"
       payload = {
         solution: solution,


### PR DESCRIPTION
Thanks for the fun RubyConf 2017 presentation!  This change will make it easier for someone to follow your README instructions to get your demo started locally -- otherwise they would be greeted with a `cannot load such file -- cfop` error.
